### PR TITLE
new keyExists method added to the luaTable

### DIFF
--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -293,6 +293,16 @@ func TestProxyFactory(t *testing.T) {
 		responseData:set("keys", responseData:keys())
 		responseData:del("to_be_removed")
 
+		if responseData:keyExists("to_be_removed")
+		then
+			custom_error("unexpected key")
+		end
+
+		if not responseData:keyExists("bar")
+		then
+			custom_error("missing required key")
+		end
+
 		resp:headers("Content-Type", "application/xml")
 		resp:statusCode(200)
 		resp:body(resp:body() .. " bar" .. resp:headers("unknown"))`,

--- a/proxy/response.go
+++ b/proxy/response.go
@@ -24,6 +24,7 @@ func registerResponseTable(resp *proxy.Response, b *binder.Binder) {
 	tab.Dynamic("len", tableLen)
 	tab.Dynamic("del", tableDel)
 	tab.Dynamic("keys", tableKeys)
+	tab.Dynamic("keyExists", tableKeyExists)
 
 	list := b.Table("luaList")
 	list.Static("new", func(c *binder.Context) error {
@@ -143,6 +144,19 @@ func (*response) data(c *binder.Context) error {
 	}
 	c.Push().Data(&luaTable{data: resp.Data}, "luaTable")
 
+	return nil
+}
+
+func tableKeyExists(c *binder.Context) error {
+	if c.Top() != 2 {
+		return errNeedsArguments
+	}
+	tab, ok := c.Arg(1).Data().(*luaTable)
+	if !ok {
+		return errResponseExpected
+	}
+	_, ok = tab.data[c.Arg(2).String()]
+	c.Push().Bool(ok)
 	return nil
 }
 


### PR DESCRIPTION
so users can verify if a key exists before trying to access it (and crashing the snippet execution). Example:

```
		if responseData:keyExists("unexistent")
		then
			custom_error("unexpected key")
		end
		if not responseData:keyExists("bar")
		then
			custom_error("missing required key")
		end
```