### PR TITLE
skip check for md5 usage that does not need to be secure

### DIFF
--- a/config.go
+++ b/config.go
@@ -93,7 +93,7 @@ func Parse(l logging.Logger, e config.ExtraConfig, namespace string) (Config, er
 			return res, ErrWrongChecksumType(source)
 		}
 		content, _ := res.SourceLoader.Get(source)
-		hash := md5.New()
+		hash := md5.New() // skipcq: GO-S1023, GSC-G401
 		if _, err := io.Copy(hash, bytes.NewBuffer([]byte(content))); err != nil {
 			return res, err
 		}


### PR DESCRIPTION
skip check for md5 usage that does not need to be secure