### PR TITLE
the table getter supports client errors from lura

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,7 +1,6 @@
 package lua
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -30,7 +29,7 @@ func TestParse(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 		return
 	}
-	b, _ := ioutil.ReadFile(source)
+	b, _ := os.ReadFile(source)
 	if src, ok := cfg.Get(source); !ok || src != string(b) {
 		t.Errorf("wrong content %s", string(b))
 	}
@@ -46,7 +45,7 @@ func TestParse(t *testing.T) {
 }
 
 func TestParse_live(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "test_parse_live")
+	tmpfile, err := os.CreateTemp("", "test_parse_live")
 	if err != nil {
 		t.Error(err)
 		return
@@ -85,7 +84,7 @@ func TestParse_live(t *testing.T) {
 		t.Errorf("wrong content %s", src)
 	}
 
-	if err := ioutil.WriteFile(source, []byte(finalContent), 0644); err != nil {
+	if err := os.WriteFile(source, []byte(finalContent), 0644); err != nil {
 		t.Error(err)
 		return
 	}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -220,7 +220,7 @@ func TestProxyFactory(t *testing.T) {
 	}
 
 	dummyProxyFactory := proxy.FactoryFunc(func(_ *config.EndpointConfig) (proxy.Proxy, error) {
-		return func(ctx context.Context, req *proxy.Request) (*proxy.Response, error) {
+		return func(_ context.Context, req *proxy.Request) (*proxy.Response, error) {
 			if req.Method != "POST" {
 				t.Errorf("unexpected method %s", req.Method)
 			}
@@ -416,7 +416,7 @@ func Test_Issue7(t *testing.T) {
 	json.Unmarshal([]byte(response), &r)
 
 	dummyProxyFactory := proxy.FactoryFunc(func(_ *config.EndpointConfig) (proxy.Proxy, error) {
-		return func(ctx context.Context, req *proxy.Request) (*proxy.Response, error) {
+		return func(_ context.Context, _ *proxy.Request) (*proxy.Response, error) {
 			return &proxy.Response{
 				Data: r,
 				Metadata: proxy.Metadata{
@@ -488,7 +488,7 @@ func Test_jsonNumber(t *testing.T) {
 	encoding.JSONDecoder(strings.NewReader(response), &r)
 
 	dummyProxyFactory := proxy.FactoryFunc(func(_ *config.EndpointConfig) (proxy.Proxy, error) {
-		return func(ctx context.Context, req *proxy.Request) (*proxy.Response, error) {
+		return func(_ context.Context, _ *proxy.Request) (*proxy.Response, error) {
 			return &proxy.Response{
 				Data: r,
 				Metadata: proxy.Metadata{
@@ -564,7 +564,7 @@ func Test_keyValConverter(t *testing.T) {
 	}
 
 	dummyProxyFactory := proxy.FactoryFunc(func(_ *config.EndpointConfig) (proxy.Proxy, error) {
-		return func(ctx context.Context, req *proxy.Request) (*proxy.Response, error) {
+		return func(_ context.Context, _ *proxy.Request) (*proxy.Response, error) {
 			return &proxy.Response{
 				Data: r,
 				Metadata: proxy.Metadata{
@@ -644,7 +644,7 @@ func Test_listGrowsWhenUpperIndexOutOfBound(t *testing.T) {
 	r := map[string]interface{}{}
 
 	dummyProxyFactory := proxy.FactoryFunc(func(_ *config.EndpointConfig) (proxy.Proxy, error) {
-		return func(ctx context.Context, req *proxy.Request) (*proxy.Response, error) {
+		return func(_ context.Context, _ *proxy.Request) (*proxy.Response, error) {
 			return &proxy.Response{
 				Data: r,
 				Metadata: proxy.Metadata{
@@ -730,7 +730,7 @@ func Test_tableGetSupportsClientErrors(t *testing.T) {
 	}
 
 	dummyProxyFactory := proxy.FactoryFunc(func(_ *config.EndpointConfig) (proxy.Proxy, error) {
-		return func(ctx context.Context, req *proxy.Request) (*proxy.Response, error) {
+		return func(_ context.Context, _ *proxy.Request) (*proxy.Response, error) {
 			return &proxy.Response{
 				Data: map[string]interface{}{
 					"error_backend_alias_a": errA,

--- a/router/gin/lua_test.go
+++ b/router/gin/lua_test.go
@@ -1,7 +1,7 @@
 package gin
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -58,7 +58,7 @@ func TestHandlerFactory(t *testing.T) {
 			if e := c.Query("extra"); e != "foo" {
 				t.Errorf("unexpected querystring extra: '%s'", e)
 			}
-			b, err := ioutil.ReadAll(c.Request.Body)
+			b, err := io.ReadAll(c.Request.Body)
 			if err != nil {
 				t.Error(err)
 				return

--- a/router/mux/lua_test.go
+++ b/router/mux/lua_test.go
@@ -1,7 +1,7 @@
 package mux
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -52,7 +52,7 @@ func TestHandlerFactory(t *testing.T) {
 			// if id := c.Param("id"); id != "42" {
 			// 	t.Errorf("unexpected param id: %s", id)
 			// }
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Error(err)
 				return


### PR DESCRIPTION
so the lua scripts can operate with responses decorated by the lura client when the return_error_details flag is enabled