### PR TITLE
Improved Lua script errors

### DIFF
--- a/binder.go
+++ b/binder.go
@@ -1,0 +1,51 @@
+package lua
+
+import (
+	"strings"
+
+	"github.com/krakendio/binder"
+)
+
+type BinderWrapper struct {
+	binder    *binder.Binder
+	sourceMap *SourceMap
+}
+
+func NewBinderWrapper(binderOptions binder.Options) BinderWrapper {
+	b := binder.New(binderOptions)
+	m := NewSourceMap()
+	return BinderWrapper{b, &m}
+}
+
+func (b BinderWrapper) GetBinder() *binder.Binder {
+	return b.binder
+}
+
+func (b BinderWrapper) WithConfig(cfg *Config) error {
+	var srcBlock []string
+	for _, source := range cfg.Sources {
+		src, ok := cfg.Get(source)
+		if !ok {
+			return ErrUnknownSource(source)
+		}
+		srcBlock = append(srcBlock, src)
+		b.sourceMap.Append(source, src)
+	}
+	if len(srcBlock) > 0 {
+		if err := b.binder.DoString(strings.Join(srcBlock, "\n")); err != nil {
+			return ToError(err, b.sourceMap)
+		}
+	}
+
+	return nil
+}
+
+func (b BinderWrapper) WithCode(key string, src string) error {
+	if err := b.binder.DoString(src); err != nil {
+		v := *b.sourceMap
+		v.Append(key, src)
+
+		return ToError(err, &v)
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/gin-gonic/gin v1.9.1
-	github.com/krakendio/binder v0.0.0-20241024141510-eeb24543bdb1
+	github.com/krakendio/binder v0.0.0-20241114194202-a3efb1159b42
 	github.com/luraproject/lura/v2 v2.7.0
 	github.com/yuin/gopher-lua v1.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/klauspost/cpuid/v2 v2.2.7 h1:ZWSB3igEs+d0qvnxR/ZBzXVmxkgt8DdzP6m9pfuVLDM=
 github.com/klauspost/cpuid/v2 v2.2.7/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/knz/go-libedit v1.10.1/go.mod h1:MZTVkCWyz0oBc7JOWP3wNAzd002ZbM/5hgShxwh4x8M=
-github.com/krakendio/binder v0.0.0-20241024141510-eeb24543bdb1 h1:hurbmtCzGrwV98WPHXR+D/pzHOkyYy+n4GEpKKA2MG0=
-github.com/krakendio/binder v0.0.0-20241024141510-eeb24543bdb1/go.mod h1:CYIubvHjRQrAM2JZn4pv/Whrmo57K2cHOv2jLVQk4aI=
+github.com/krakendio/binder v0.0.0-20241114194202-a3efb1159b42 h1:kLYwWm+SNQa89DLDznGDjHK0JlhxByUK4BT64S+wTL8=
+github.com/krakendio/binder v0.0.0-20241114194202-a3efb1159b42/go.mod h1:CYIubvHjRQrAM2JZn4pv/Whrmo57K2cHOv2jLVQk4aI=
 github.com/krakendio/flatmap v1.1.1 h1:rGBNVpBY0pMk6cLOwerVzoKY4HELnpu0xvqB231lOCQ=
 github.com/krakendio/flatmap v1.1.1/go.mod h1:KBuVkiH5BcBFRa5A1HdSHDn8a8LzsyRTKZArX0vqTbo=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=

--- a/lua/add.lua
+++ b/lua/add.lua
@@ -1,0 +1,7 @@
+function add (a)
+    local sum = 0
+    for i,v in ipairs(a) do
+      sum = sum + v
+    end
+    return sum
+end

--- a/lua/bad-code.lua
+++ b/lua/bad-code.lua
@@ -1,0 +1,6 @@
+function some_func (n)
+    return n+1
+end
+
+local bad_idea = some_func.really_bad()
+-- Intentional comment

--- a/lua/bad-func.lua
+++ b/lua/bad-func.lua
@@ -1,0 +1,4 @@
+function badfunc (n)
+  -- LGTM
+  return bad_idea(n)
+end

--- a/lua/env.lua
+++ b/lua/env.lua
@@ -1,0 +1,3 @@
+-- Setting up env
+local var1 = "hello"
+local var2 = "hi"

--- a/proxy/http_test.go
+++ b/proxy/http_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 
 	"github.com/krakendio/binder"
+	lua "github.com/krakendio/krakend-lua/v2"
 )
 
 func Example_RegisterBackendModule() {
@@ -26,18 +27,17 @@ func Example_RegisterBackendModule() {
 	}))
 	defer ts.Close()
 
-	bindr := binder.New(binder.Options{
+	bindr := lua.NewBinderWrapper(binder.Options{
 		SkipOpenLibs:        true,
 		IncludeGoStackTrace: true,
 	})
 
-	registerHTTPRequest(context.Background(), bindr)
+	registerHTTPRequest(context.Background(), bindr.GetBinder())
 
 	code := fmt.Sprintf("local url = '%s'\n%s", ts.URL, sampleLuaCode)
 
-	if err := bindr.DoString(code); err != nil {
-		fmt.Println(err.(*binder.Error).Error())
-		err.(*binder.Error).Print()
+	if err := bindr.WithCode("test-code", code); err != nil {
+		fmt.Println(err.Error())
 	}
 
 	// output:

--- a/proxy/proxy_benchmark_test.go
+++ b/proxy/proxy_benchmark_test.go
@@ -86,3 +86,115 @@ func BenchmarkProxyFactory(b *testing.B) {
 	}
 	localResponse = resp
 }
+
+func BenchmarkProxyFactoryWithCustomError(b *testing.B) {
+	buff := bytes.NewBuffer(make([]byte, 1024))
+	logger, err := logging.NewLogger("ERROR", buff, "pref")
+	if err != nil {
+		b.Error("building the logger:", err.Error())
+		return
+	}
+
+	dummyProxyFactory := proxy.FactoryFunc(func(_ *config.EndpointConfig) (proxy.Proxy, error) {
+		return func(_ context.Context, _ *proxy.Request) (*proxy.Response, error) {
+			return &proxy.Response{
+				Data: map[string]interface{}{"ok": true},
+				Metadata: proxy.Metadata{
+					Headers: map[string][]string{},
+				},
+			}, nil
+		}, nil
+	})
+
+	URL, _ := url.Parse("https://some.host.tld/path/to/resource?and=querystring")
+
+	prxy, err := ProxyFactory(logger, dummyProxyFactory).New(&config.EndpointConfig{
+		Endpoint: "/",
+		ExtraConfig: config.ExtraConfig{
+			ProxyNamespace: map[string]interface{}{
+				"sources": []interface{}{
+					"../lua/env.lua",
+					"../lua/factorial.lua",
+				},
+
+				"pre": "local t = 1\ncustom_error(\"meh\")",
+			},
+		},
+	})
+
+	if err != nil {
+		b.Error(err)
+	}
+
+	var resp *proxy.Response
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		resp, _ = prxy(context.Background(), &proxy.Request{
+			Method:  "GET",
+			Path:    "/some-path",
+			Params:  map[string]string{"Id": "42"},
+			Headers: map[string][]string{},
+			URL:     URL,
+		})
+	}
+	localResponse = resp
+}
+
+func BenchmarkProxyFactoryWithLuaError(b *testing.B) {
+	buff := bytes.NewBuffer(make([]byte, 1024))
+	logger, err := logging.NewLogger("ERROR", buff, "pref")
+	if err != nil {
+		b.Error("building the logger:", err.Error())
+		return
+	}
+
+	dummyProxyFactory := proxy.FactoryFunc(func(_ *config.EndpointConfig) (proxy.Proxy, error) {
+		return func(_ context.Context, _ *proxy.Request) (*proxy.Response, error) {
+			return &proxy.Response{
+				Data: map[string]interface{}{"ok": true},
+				Metadata: proxy.Metadata{
+					Headers: map[string][]string{},
+				},
+			}, nil
+		}, nil
+	})
+
+	URL, _ := url.Parse("https://some.host.tld/path/to/resource?and=querystring")
+
+	prxy, err := ProxyFactory(logger, dummyProxyFactory).New(&config.EndpointConfig{
+		Endpoint: "/",
+		ExtraConfig: config.ExtraConfig{
+			ProxyNamespace: map[string]interface{}{
+				"sources": []interface{}{
+					"../lua/env.lua",
+					"../lua/factorial.lua",
+				},
+
+				"pre": "lokal t = 1\ncustom_error(\"meh\")",
+			},
+		},
+	})
+
+	if err != nil {
+		b.Error(err)
+	}
+
+	var resp *proxy.Response
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		resp, _ = prxy(context.Background(), &proxy.Request{
+			Method:  "GET",
+			Path:    "/some-path",
+			Params:  map[string]string{"Id": "42"},
+			Headers: map[string][]string{},
+			URL:     URL,
+		})
+	}
+	localResponse = resp
+}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestProxyFactory_luaError(t *testing.T) {
-	var luaPreErrorTestTable = []struct {
+	var luaErrorTestTable = []struct {
 		Name          string
 		Cfg           map[string]interface{}
 		ExpectedError string
@@ -117,13 +117,6 @@ func TestProxyFactory_luaError(t *testing.T) {
 			},
 			ExpectedError: "attempt to call a non-function object (bad-func.lua:L3)",
 		},
-	}
-
-	var luaPostErrorTestTable = []struct {
-		Name          string
-		Cfg           map[string]interface{}
-		ExpectedError string
-	}{
 		{
 			Name: "Post: Inline syntax error",
 			Cfg: map[string]interface{}{
@@ -209,8 +202,7 @@ func TestProxyFactory_luaError(t *testing.T) {
 		},
 	}
 
-	tests := append(luaPreErrorTestTable, luaPostErrorTestTable...)
-	for _, test := range tests {
+	for _, test := range luaErrorTestTable {
 		t.Run(test.Name, func(t *testing.T) {
 			logger, err := logging.NewLogger("ERROR", bytes.NewBuffer(make([]byte, 1024)), "pref")
 			if err != nil {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -19,6 +19,246 @@ import (
 	"github.com/luraproject/lura/v2/transport/http/client"
 )
 
+func TestProxyFactory_luaError(t *testing.T) {
+	var luaPreErrorTestTable = []struct {
+		Name          string
+		Cfg           map[string]interface{}
+		ExpectedError string
+	}{
+		{
+			Name: "Pre: Syntax error",
+			Cfg: map[string]interface{}{
+				"pre": "local req = request.load()\nlokal a = 1()\nlocal b = 2",
+			},
+			ExpectedError: "'a': parse error (pre-script:L2)",
+		},
+		{
+			Name: "Pre: Inline syntax error",
+			Cfg: map[string]interface{}{
+				"pre": "local req = request.load();lokal a = 1();local b = 2",
+			},
+			ExpectedError: "'a': parse error (pre-script:L1)",
+		},
+		{
+			Name: "Pre: Inline semicolon separated",
+			Cfg: map[string]interface{}{
+				"pre": "local req = request.load();method_does_not_exist();local test = 1",
+			},
+			ExpectedError: "attempt to call a non-function object (pre-script:L1)",
+		},
+		{
+			Name: "Pre: Inline",
+			Cfg: map[string]interface{}{
+				"pre": "local req = request.load()\nmethod_does_not_exist()\nlocal test = 1",
+			},
+			ExpectedError: "attempt to call a non-function object (pre-script:L2)",
+		},
+		{
+			Name: "Pre: Multiline",
+			Cfg: map[string]interface{}{
+				"pre": `local req = request.load()
+						req:method("POST")
+						req:params("foo", "some_new_value")
+						req:headers("Accept", "application/xml")
+						req:url(req:url() .. "&more=true")
+						reqw:body(req:body() .. " foo" .. req:headers("unknown")) -- fat-fingered`,
+			},
+			ExpectedError: "attempt to index a non-table object(nil) with key 'body' (pre-script:L6)",
+		},
+		{
+			Name: "Pre: Empty custom_error",
+			Cfg: map[string]interface{}{
+				"pre": "custom_error()",
+			},
+			ExpectedError: "need arguments (pre-script:L1)",
+		},
+		{
+			Name: "Pre: Single source with bad code",
+			Cfg: map[string]interface{}{
+				"sources": []interface{}{
+					"../lua/bad-code.lua",
+				},
+				"pre": "custom_error(\"wont reach here\")",
+			},
+			ExpectedError: "attempt to index a non-table object(function) with key 'really_bad' (bad-code.lua:L5)",
+		},
+		{
+			Name: "Pre: Single source with bad method implementation",
+			Cfg: map[string]interface{}{
+				"sources": []interface{}{
+					"../lua/bad-func.lua",
+				},
+				"pre": "badfunc(1)",
+			},
+			ExpectedError: "attempt to call a non-function object (bad-func.lua:L3)",
+		},
+		{
+			Name: "Pre: Multiple sources",
+			Cfg: map[string]interface{}{
+				"sources": []interface{}{
+					"../lua/factorial.lua",
+					"../lua/bad-code.lua",
+					"../lua/add.lua",
+				},
+				"pre": "custom_error(\"wont reach here\")",
+			},
+			ExpectedError: "attempt to index a non-table object(function) with key 'really_bad' (bad-code.lua:L5)",
+		},
+		{
+			Name: "Pre: Multiple sources, bad function call",
+			Cfg: map[string]interface{}{
+				"sources": []interface{}{
+					"../lua/env.lua",
+					"../lua/factorial.lua",
+					"../lua/bad-func.lua",
+					"../lua/add.lua",
+				},
+				"pre": "badfunc(1)",
+			},
+			ExpectedError: "attempt to call a non-function object (bad-func.lua:L3)",
+		},
+	}
+
+	var luaPostErrorTestTable = []struct {
+		Name          string
+		Cfg           map[string]interface{}
+		ExpectedError string
+	}{
+		{
+			Name: "Post: Inline syntax error",
+			Cfg: map[string]interface{}{
+				"post": "local req = request.load();lokal a = 1();local b = 2",
+			},
+			ExpectedError: "'a': parse error (post-script:L1)",
+		},
+		{
+			Name: "Post: Inline semicolon separated",
+			Cfg: map[string]interface{}{
+				"post": "local req = request.load();method_does_not_exist();local test = 1",
+			},
+			ExpectedError: "attempt to call a non-function object (post-script:L1)",
+		},
+		{
+			Name: "Post: Inline",
+			Cfg: map[string]interface{}{
+				"post": "local req = request.load()\nmethod_does_not_exist()\nlocal test = 1",
+			},
+			ExpectedError: "attempt to call a non-function object (post-script:L2)",
+		},
+		{
+			Name: "Post: Multiline",
+			Cfg: map[string]interface{}{
+				"post": `local resp = response.load()
+						local responseData = resp:data()
+						local data = {}
+						local col = responseDataBad:get("items")`,
+			},
+			ExpectedError: "attempt to index a non-table object(nil) with key 'get' (post-script:L4)",
+		},
+		{
+			Name: "Post: Empty custom_error",
+			Cfg: map[string]interface{}{
+				"post": "custom_error()",
+			},
+			ExpectedError: "need arguments (post-script:L1)",
+		},
+		{
+			Name: "Post: Single source with bad code",
+			Cfg: map[string]interface{}{
+				"sources": []interface{}{
+					"../lua/bad-code.lua",
+				},
+				"post": "custom_error(\"wont reach here\")",
+			},
+			ExpectedError: "attempt to index a non-table object(function) with key 'really_bad' (bad-code.lua:L5)",
+		},
+		{
+			Name: "Post: Single source with bad method implementation",
+			Cfg: map[string]interface{}{
+				"sources": []interface{}{
+					"../lua/bad-func.lua",
+				},
+				"post": "badfunc(1)",
+			},
+			ExpectedError: "attempt to call a non-function object (bad-func.lua:L3)",
+		},
+		{
+			Name: "Post: Multiple sources",
+			Cfg: map[string]interface{}{
+				"sources": []interface{}{
+					"../lua/factorial.lua",
+					"../lua/bad-code.lua",
+					"../lua/add.lua",
+				},
+				"post": "custom_error(\"wont reach here\")",
+			},
+			ExpectedError: "attempt to index a non-table object(function) with key 'really_bad' (bad-code.lua:L5)",
+		},
+		{
+			Name: "Post: Multiple sources, bad function call",
+			Cfg: map[string]interface{}{
+				"sources": []interface{}{
+					"../lua/env.lua",
+					"../lua/factorial.lua",
+					"../lua/bad-func.lua",
+					"../lua/add.lua",
+				},
+				"post": "badfunc(1)",
+			},
+			ExpectedError: "attempt to call a non-function object (bad-func.lua:L3)",
+		},
+	}
+
+	tests := append(luaPreErrorTestTable, luaPostErrorTestTable...)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			logger, err := logging.NewLogger("ERROR", bytes.NewBuffer(make([]byte, 1024)), "pref")
+			if err != nil {
+				t.Error("building the logger:", err.Error())
+				return
+			}
+
+			explosive := proxy.FactoryFunc(func(_ *config.EndpointConfig) (proxy.Proxy, error) {
+				return func(_ context.Context, _ *proxy.Request) (*proxy.Response, error) {
+					return &proxy.Response{}, nil
+				}, nil
+			})
+
+			prxy, err := ProxyFactory(logger, explosive).New(&config.EndpointConfig{
+				Endpoint: "/",
+				ExtraConfig: config.ExtraConfig{
+					ProxyNamespace: test.Cfg,
+				},
+			})
+
+			if err != nil {
+				t.Error(err)
+			}
+
+			URL, _ := url.Parse("https://some.host.tld/path/to/resource?and=querystring")
+
+			resp, err := prxy(context.Background(), &proxy.Request{
+				Method:  "GET",
+				Path:    "/some-path",
+				Params:  map[string]string{"Id": "42"},
+				Headers: map[string][]string{},
+				URL:     URL,
+				Body:    io.NopCloser(strings.NewReader("initial req content")),
+			})
+
+			if resp != nil {
+				t.Errorf("unexpected response: %v", resp)
+				return
+			}
+
+			if e := err.Error(); e != test.ExpectedError {
+				t.Errorf("unexpected error, have: '%s', want: '%s' (%T)", e, test.ExpectedError, err)
+				return
+			}
+		})
+	}
+}
+
 func TestProxyFactory_error(t *testing.T) {
 	testProxyFactoryError(t, `custom_error('expect me')`, "expect me", "", false, 0)
 	testProxyFactoryPostError(t, `custom_error('expect me')`, "expect me", "", false, 0)

--- a/router/mux/lua_test.go
+++ b/router/mux/lua_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/krakendio/krakend-lua/v2/router"
@@ -174,4 +175,138 @@ func TestHandlerFactory_errorHTTPWithContentType(t *testing.T) {
 		t.Errorf("unexpected content-type %s", h)
 		return
 	}
+}
+
+func TestHandlerFactory_luaError(t *testing.T) {
+	var luaPreErrorTestTable = []struct {
+		Name          string
+		Cfg           map[string]interface{}
+		ExpectedError string
+	}{
+		{
+			Name: "Pre: Syntax error",
+			Cfg: map[string]interface{}{
+				"pre": "local c = ctx.load()\nlokal a = 1()\nlocal b = 2",
+			},
+			ExpectedError: "'a': parse error (pre-script:L2)",
+		},
+		{
+			Name: "Pre: Inline syntax error",
+			Cfg: map[string]interface{}{
+				"pre": "local c = ctx.load();lokal a = 1();local b = 2",
+			},
+			ExpectedError: "'a': parse error (pre-script:L1)",
+		},
+		{
+			Name: "Pre: Inline semicolon separated",
+			Cfg: map[string]interface{}{
+				"pre": "local c = ctx.load();method_does_not_exist();local test = 1",
+			},
+			ExpectedError: "attempt to call a non-function object (pre-script:L1)",
+		},
+		{
+			Name: "Pre: Inline",
+			Cfg: map[string]interface{}{
+				"pre": "local c = ctx.load()\nmethod_does_not_exist()\nlocal test = 1",
+			},
+			ExpectedError: "attempt to call a non-function object (pre-script:L2)",
+		},
+		{
+			Name: "Pre: Multiline",
+			Cfg: map[string]interface{}{
+				"pre": `local req = ctx.load()
+						req:method("POST")
+						req:params("foo", "some_new_value")
+						req:headers("Accept", "application/xml")
+						req:url(req:url() .. "&more=true")
+						req:query("extra", "foo")
+						reqw:body(req:body().."fooooooo")`,
+			},
+			ExpectedError: "attempt to index a non-table object(nil) with key 'body' (pre-script:L7)",
+		},
+		{
+			Name: "Pre: Empty custom_error",
+			Cfg: map[string]interface{}{
+				"pre": "custom_error()",
+			},
+			ExpectedError: "need arguments (pre-script:L1)",
+		},
+		{
+			Name: "Pre: Single source with bad code",
+			Cfg: map[string]interface{}{
+				"sources": []interface{}{
+					"../../lua/bad-code.lua",
+				},
+				"pre": "custom_error(\"wont reach here\")",
+			},
+			ExpectedError: "attempt to index a non-table object(function) with key 'really_bad' (bad-code.lua:L5)",
+		},
+		{
+			Name: "Pre: Single source with bad method implementation",
+			Cfg: map[string]interface{}{
+				"sources": []interface{}{
+					"../../lua/bad-func.lua",
+				},
+				"pre": "badfunc(1)",
+			},
+			ExpectedError: "attempt to call a non-function object (bad-func.lua:L3)",
+		},
+		{
+			Name: "Pre: Multiple sources",
+			Cfg: map[string]interface{}{
+				"sources": []interface{}{
+					"../../lua/factorial.lua",
+					"../../lua/bad-code.lua",
+					"../../lua/add.lua",
+				},
+				"pre": "custom_error(\"wont reach here\")",
+			},
+			ExpectedError: "attempt to index a non-table object(function) with key 'really_bad' (bad-code.lua:L5)",
+		},
+		{
+			Name: "Pre: Multiple sources, bad function call",
+			Cfg: map[string]interface{}{
+				"sources": []interface{}{
+					"../../lua/env.lua",
+					"../../lua/factorial.lua",
+					"../../lua/bad-func.lua",
+					"../../lua/add.lua",
+				},
+				"pre": "badfunc(1)",
+			},
+			ExpectedError: "attempt to call a non-function object (bad-func.lua:L3)",
+		},
+	}
+
+	for _, test := range luaPreErrorTestTable {
+		t.Run(test.Name, func(t *testing.T) {
+			cfg := &config.EndpointConfig{
+				Endpoint: "/",
+				ExtraConfig: config.ExtraConfig{
+					router.Namespace: test.Cfg,
+				},
+			}
+
+			hf := func(_ *config.EndpointConfig, _ proxy.Proxy) http.HandlerFunc {
+				return func(_ http.ResponseWriter, _ *http.Request) {
+					t.Error("the handler shouldn't be executed")
+				}
+			}
+			handler := HandlerFactory(logging.NoOp, hf, func(_ *http.Request) map[string]string {
+				return map[string]string{}
+			})(cfg, proxy.NoopProxy)
+
+			req, _ := http.NewRequest("GET", "/some-path/42?id=1", http.NoBody)
+			req.Header.Set("Accept", "application/json")
+			w := httptest.NewRecorder()
+
+			handler(w, req)
+
+			reqErr := strings.Trim(w.Body.String(), "\n")
+			if reqErr != test.ExpectedError {
+				t.Errorf("unexpected error, have: '%s', want: '%s'", reqErr, test.ExpectedError)
+			}
+		})
+	}
+
 }

--- a/sourcemap.go
+++ b/sourcemap.go
@@ -1,0 +1,40 @@
+package lua
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+)
+
+type SourceMap []struct {
+	Lines int
+	Path  string
+}
+
+func NewSourceMap() SourceMap {
+	return SourceMap{}
+}
+
+func (s *SourceMap) Append(path string, src string) *SourceMap {
+	src = strings.Trim(src, "\n")
+	lines := strings.Count(src, "\n") + 1
+
+	*s = append(*s, struct {
+		Lines int
+		Path  string
+	}{lines, path})
+
+	return s
+}
+
+func (s *SourceMap) AffectedSource(line int) (string, int, error) {
+	count := 0
+	for _, source := range *s {
+		count += source.Lines
+		if count >= line {
+			relativeLine := source.Lines - (count - line)
+			return filepath.Base(source.Path), relativeLine, nil
+		}
+	}
+	return "", 0, errors.New("line number out of bounds")
+}

--- a/sourcemap_test.go
+++ b/sourcemap_test.go
@@ -1,0 +1,136 @@
+package lua
+
+import (
+	"testing"
+)
+
+var codeExamples = map[string]string{
+	"single-line":     "line1",
+	"inline":          "line1\nline2\nline3",
+	"inline-trailing": "line1\nline2\nline3\n",
+	"multi-line": `line1
+		line2
+		line3
+		line4
+		
+		line6`,
+}
+
+type TestConfig struct {
+	path string
+	src  string
+}
+type TestCase struct {
+	line                 int
+	expectedPath         string
+	expectedRelativeLine int
+	expectError          bool
+}
+
+func TestAffectedSource(t *testing.T) {
+	tests := map[string]struct {
+		config []TestConfig
+		cases  []TestCase
+	}{
+		"Empty case": {
+			config: []TestConfig{},
+			cases: []TestCase{
+				{1, "", 0, true},
+			},
+		},
+		"Simple case": {
+			config: []TestConfig{
+				{"test.src", codeExamples["single-line"]},
+			},
+			cases: []TestCase{
+				{1, "test.src", 1, false},
+			},
+		},
+		"Single inline": {
+			config: []TestConfig{
+				{"test1.src", codeExamples["inline"]},
+			},
+			cases: []TestCase{
+				{1, "test1.src", 1, false},
+				{3, "test1.src", 3, false},
+			},
+		},
+		"Single inline trailing delimiter": {
+			config: []TestConfig{
+				{"test1.src", codeExamples["inline-trailing"]},
+			},
+			cases: []TestCase{
+				{1, "test1.src", 1, false},
+				{3, "test1.src", 3, false},
+				{4, "", 0, true},
+			},
+		},
+		"Multiple sources of single lines": {
+			config: []TestConfig{
+				{"test1.src", codeExamples["single-line"]},
+				{"test2.src", codeExamples["single-line"]},
+			},
+			cases: []TestCase{
+				{1, "test1.src", 1, false},
+				{2, "test2.src", 1, false},
+			},
+		},
+		"Multiple sources": {
+			config: []TestConfig{
+				{"test1.src", codeExamples["single-line"]},
+				{"test2.src", codeExamples["single-line"]},
+				{"test3.src", codeExamples["multi-line"]},
+				{"test4.src", codeExamples["multi-line"]},
+				{"test5.src", codeExamples["single-line"]},
+			},
+			cases: []TestCase{
+				{1, "test1.src", 1, false},
+				{2, "test2.src", 1, false},
+				{3, "test3.src", 1, false},
+				{5, "test3.src", 3, false},
+				{10, "test4.src", 2, false},
+				{14, "test4.src", 6, false},
+				{15, "test5.src", 1, false},
+				{16, "", 0, true},
+			},
+		},
+		"Returns only the affected file name": {
+			config: []TestConfig{
+				{"test1.src", codeExamples["single-line"]},
+				{"./test2.src", codeExamples["single-line"]},
+				{"/path/test3.src", codeExamples["single-line"]},
+				{"/path/path2/test4.src", codeExamples["single-line"]},
+				{"../path2/test5.src", codeExamples["single-line"]},
+			},
+			cases: []TestCase{
+				{1, "test1.src", 1, false},
+				{2, "test2.src", 1, false},
+				{3, "test3.src", 1, false},
+				{4, "test4.src", 1, false},
+				{5, "test5.src", 1, false},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			sourceMap := NewSourceMap()
+			for _, cfg := range test.config {
+				sourceMap.Append(cfg.path, cfg.src)
+			}
+
+			for _, c := range test.cases {
+				affectedPath, relativeLine, err := sourceMap.AffectedSource(c.line)
+				if err != nil && !c.expectError {
+					t.Errorf("case '%s' return an unexpected error", name)
+				}
+				if relativeLine != c.expectedRelativeLine {
+					t.Errorf("unexpected relative line in '%s', expected=%d, got=%d", name, c.expectedRelativeLine, relativeLine)
+				}
+				if affectedPath != c.expectedPath {
+					t.Errorf("unexpected path in '%s', expected=%s, got=%s", name, c.expectedPath, affectedPath)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
:warning::warning: ~~Depends on https://github.com/krakend/binder/pull/3 , Lua syntax errors won't be properly parsed until binder is upgraded~~ Binder is now properly reporting syntax errors

---

Adding more details to Lua errors to quickly detect code issues:

* Added line number
* Added file name, this can be `pre-script` or `post-script` if the issue is either the `pre` or `post` config declarations

Log example
```
{"@timestamp":"2024-11-14T12:42:02.704+00:00", "@version": 1, "level": "ERROR", "message": "[ENDPOINT: /lua/backend] attempt to call a non-function object (pre-script:L3)", "module": "KRAKEND"}
```

TODO
* Check live reloads
* Binder wrapper tests
* Check Proxy skipNext error