### PR TITLE
Allow deleting request and response headers

### DIFF
--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -447,7 +447,7 @@ func testProxyFactoryPostError(t *testing.T, code, errMsg, contentType string, i
 	}
 }
 
-func TestProxyFactory(t *testing.T) {
+func TestProxyFactory(t *testing.T) { // skipcq: GO-R1005
 	buff := bytes.NewBuffer(make([]byte, 1024))
 	logger, err := logging.NewLogger("ERROR", buff, "pref")
 	if err != nil {

--- a/proxy/request.go
+++ b/proxy/request.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/krakendio/binder"
 	"github.com/luraproject/lura/v2/proxy"
+	glua "github.com/yuin/gopher-lua"
 )
 
 func registerRequestTable(req *proxy.Request, b *binder.Binder) {
@@ -136,6 +137,12 @@ func (*ProxyRequest) headers(c *binder.Context) error {
 		}
 	case 3:
 		key := textproto.CanonicalMIMEHeaderKey(c.Arg(2).String())
+
+		_, isNil := c.Arg(3).Any().(*glua.LNilType)
+		if isNil {
+			delete(req.Headers, key)
+			return nil
+		}
 		req.Headers[key] = []string{c.Arg(3).String()}
 	}
 

--- a/proxy/response.go
+++ b/proxy/response.go
@@ -9,6 +9,7 @@ import (
 	"github.com/krakendio/binder"
 	lua "github.com/krakendio/krakend-lua/v2"
 	"github.com/luraproject/lura/v2/proxy"
+	glua "github.com/yuin/gopher-lua"
 )
 
 func registerResponseTable(resp *proxy.Response, b *binder.Binder) {
@@ -86,7 +87,14 @@ func (*ProxyResponse) headers(c *binder.Context) error {
 			c.Push().String(headers[0])
 		}
 	case 3:
-		resp.Metadata.Headers[http.CanonicalHeaderKey(c.Arg(2).String())] = []string{c.Arg(3).String()}
+		key := http.CanonicalHeaderKey(c.Arg(2).String())
+
+		_, isNil := c.Arg(3).Any().(*glua.LNilType)
+		if isNil {
+			delete(resp.Metadata.Headers, key)
+			return nil
+		}
+		resp.Metadata.Headers[key] = []string{c.Arg(3).String()}
 	}
 
 	return nil


### PR DESCRIPTION
Now the `request` and `response` objects accept deleting headers, for example

**Request**
```
local req = request.load()
req:headers("X-To-Remove", nil)
```

**Response (with no-op)**
```
local res = response.load()
res:headers("X-Fastly-Request-Id", nil)
```