### PR TITLE
Allow deleting ctx headers

### DIFF
--- a/router/gin/lua.go
+++ b/router/gin/lua.go
@@ -16,6 +16,7 @@ import (
 	"github.com/luraproject/lura/v2/logging"
 	"github.com/luraproject/lura/v2/proxy"
 	krakendgin "github.com/luraproject/lura/v2/router/gin"
+	glua "github.com/yuin/gopher-lua"
 )
 
 func Register(l logging.Logger, extraConfig config.ExtraConfig, engine *gin.Engine) {
@@ -223,6 +224,11 @@ func (*ginContext) requestHeaders(c *binder.Context) error {
 	case 2:
 		c.Push().String(req.Request.Header.Get(c.Arg(2).String()))
 	case 3:
+		_, isNil := c.Arg(3).Any().(*glua.LNilType)
+		if isNil {
+			req.Request.Header.Del(c.Arg(2).String())
+			return nil
+		}
 		req.Request.Header.Set(c.Arg(2).String(), c.Arg(3).String())
 	}
 

--- a/router/gin/lua_test.go
+++ b/router/gin/lua_test.go
@@ -27,6 +27,8 @@ func TestHandlerFactory(t *testing.T) {
 		req:method("POST")
 		req:params("foo", "some_new_value")
 		req:headers("Accept", "application/xml")
+		req:headers("X-To-Delete", nil)
+		req:headers("X-TO-DELETE-LOWER", nil)
 		req:url(req:url() .. "&more=true")
 		req:host(req:host() .. ".newtld")
 		req:query("extra", "foo")
@@ -45,6 +47,12 @@ func TestHandlerFactory(t *testing.T) {
 			}
 			if accept := c.Request.Header.Get("Accept"); accept != "application/xml" {
 				t.Errorf("unexpected accept header: %s", accept)
+			}
+			if toDelete := c.Request.Header.Get("X-To-Delete"); len(toDelete) > 0 {
+				t.Error("unexpected header 'X-To-Delete', should have been deleted")
+			}
+			if toDeleteLower := c.Request.Header.Get("X-To-Delete-Lower"); len(toDeleteLower) > 0 {
+				t.Error("unexpected header 'X-To-Delete-Lower', should have been deleted")
 			}
 			if c.Request.Method != "POST" {
 				t.Errorf("unexpected method: %s", c.Request.Method)
@@ -76,6 +84,8 @@ func TestHandlerFactory(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/some-path/42?id=1", http.NoBody)
 	req.Host = "domain.tld"
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-To-Delete", "deleteme")
+	req.Header.Set("x-to-delete-lower", "deleteme")
 	w := httptest.NewRecorder()
 
 	engine.ServeHTTP(w, req)

--- a/router/mux/lua.go
+++ b/router/mux/lua.go
@@ -16,6 +16,7 @@ import (
 	"github.com/luraproject/lura/v2/logging"
 	"github.com/luraproject/lura/v2/proxy"
 	mux "github.com/luraproject/lura/v2/router/mux"
+	glua "github.com/yuin/gopher-lua"
 )
 
 func RegisterMiddleware(l logging.Logger, e config.ExtraConfig, pe mux.ParamExtractor, mws []mux.HandlerMiddleware) []mux.HandlerMiddleware {
@@ -202,6 +203,11 @@ func (*muxContext) headers(c *binder.Context) error {
 	case 2:
 		c.Push().String(req.Header.Get(c.Arg(2).String()))
 	case 3:
+		_, isNil := c.Arg(3).Any().(*glua.LNilType)
+		if isNil {
+			req.Header.Del(c.Arg(2).String())
+			return nil
+		}
 		req.Header.Set(c.Arg(2).String(), c.Arg(3).String())
 	}
 

--- a/router/mux/lua_test.go
+++ b/router/mux/lua_test.go
@@ -26,6 +26,8 @@ func TestHandlerFactory(t *testing.T) {
 		req:method("POST")
 		req:params("foo", "some_new_value")
 		req:headers("Accept", "application/xml")
+		req:headers("X-To-Delete", nil)
+		req:headers("X-TO-DELETE-LOWER", nil)
 		req:url(req:url() .. "&more=true")
 		req:query("extra", "foo")
 		req:body(req:body().."fooooooo")`,
@@ -40,6 +42,12 @@ func TestHandlerFactory(t *testing.T) {
 			}
 			if accept := r.Header.Get("Accept"); accept != "application/xml" {
 				t.Errorf("unexpected accept header: %s", accept)
+			}
+			if toDelete := r.Header.Get("X-To-Delete"); len(toDelete) > 0 {
+				t.Error("unexpected header 'X-To-Delete', should have been deleted")
+			}
+			if toDeleteLower := r.Header.Get("X-To-Delete-Lower"); len(toDeleteLower) > 0 {
+				t.Error("unexpected header 'X-To-Delete-Lower', should have been deleted")
 			}
 			if r.Method != "POST" {
 				t.Errorf("unexpected method: %s", r.Method)
@@ -69,6 +77,8 @@ func TestHandlerFactory(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "/some-path/42?id=1", http.NoBody)
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-To-Delete", "deleteme")
+	req.Header.Set("x-to-delete-lower", "deleteme")
 	w := httptest.NewRecorder()
 
 	handler(w, req)


### PR DESCRIPTION
Extending https://github.com/krakend/krakend-lua/pull/56 to `ctx` router decorator

**Example**
```
local req = ctx.load()
req:headers("X-To-Remove", nil)
```
