### PR TITLE
Adding headerList helper

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -112,4 +112,7 @@ func New(cfg lua.Config, next proxy.Proxy) proxy.Proxy {
 	}
 }
 
-var errNeedsArguments = errors.New("need arguments")
+var (
+	errNeedsArguments = errors.New("need arguments")
+	errInvalidLuaList = errors.New("invalid header value, must be a luaList")
+)

--- a/router/gin/lua_test.go
+++ b/router/gin/lua_test.go
@@ -29,6 +29,10 @@ func TestHandlerFactory(t *testing.T) {
 		req:headers("Accept", "application/xml")
 		req:headers("X-To-Delete", nil)
 		req:headers("X-TO-DELETE-LOWER", nil)
+		local multi = luaList.new()
+		multi:set(0, "A")
+		multi:set(1, "B")
+		req:headerList("X-Multi", multi)
 		req:url(req:url() .. "&more=true")
 		req:host(req:host() .. ".newtld")
 		req:query("extra", "foo")
@@ -47,6 +51,9 @@ func TestHandlerFactory(t *testing.T) {
 			}
 			if accept := c.Request.Header.Get("Accept"); accept != "application/xml" {
 				t.Errorf("unexpected accept header: %s", accept)
+			}
+			if multi := c.Request.Header.Values("X-Multi"); multi[0] != "A" || multi[1] != "B" {
+				t.Errorf("unexpected X-Multi header: %v", multi)
 			}
 			if toDelete := c.Request.Header.Get("X-To-Delete"); len(toDelete) > 0 {
 				t.Error("unexpected header 'X-To-Delete', should have been deleted")

--- a/router/mux/lua_test.go
+++ b/router/mux/lua_test.go
@@ -28,6 +28,10 @@ func TestHandlerFactory(t *testing.T) {
 		req:headers("Accept", "application/xml")
 		req:headers("X-To-Delete", nil)
 		req:headers("X-TO-DELETE-LOWER", nil)
+		local multi = luaList.new()
+		multi:set(0, "A")
+		multi:set(1, "B")
+		req:headerList("X-Multi", multi)
 		req:url(req:url() .. "&more=true")
 		req:query("extra", "foo")
 		req:body(req:body().."fooooooo")`,
@@ -42,6 +46,9 @@ func TestHandlerFactory(t *testing.T) {
 			}
 			if accept := r.Header.Get("Accept"); accept != "application/xml" {
 				t.Errorf("unexpected accept header: %s", accept)
+			}
+			if multi := r.Header.Values("X-Multi"); multi[0] != "A" || multi[1] != "B" {
+				t.Errorf("unexpected X-Multi header: %v", multi)
 			}
 			if toDelete := r.Header.Get("X-To-Delete"); len(toDelete) > 0 {
 				t.Error("unexpected header 'X-To-Delete', should have been deleted")


### PR DESCRIPTION
Adding a new `headerList` helper to `ctx`, `request` and `response` to deal with multi-value headers

### Example
**Config**
```
{
  "$schema": "https://www.krakend.io/schema/krakend.json",
  "version": 3,
  "port": 8080,
  "host": [
    "http://localhost:8080"
  ],
  "debug_endpoint": true,
  "endpoints": [
    {
      "endpoint": "/",
      "input_headers": ["X-Test"],
      "backend": [
        {
          "method": "GET",
          "url_pattern": "/__debug/",
          "extra_config": {
            "modifier/lua-backend": {
              "allow_open_libs": true,
              "sources": [
                  "./headers.lua"
              ],
              "pre": "tweak_headers()",
            }
          }
        }
      ]
    }
  ]
}
```
**Lua script**
```
function tweak_headers()
    local req = request.load()

    -- Replacing X-Test second value
    local h = req:headerList("X-Test")
    h:set(1, "CHANGED")
    req:headerList("X-Test", h)

    -- Adding a new header with multiple values
    local n = luaList.new()
    n:set(0, "first")
    n:set(1, "second")
    req:headerList("X-Added", n)
end
```

**Request**
```
$ curl -i -H "X-Test: A" -H "X-Test: B" http://localhost:8080
```
```
KRAKEND DEBUG: [ENDPOINT: /__debug/*] Headers: map[Accept-Encoding:[gzip] User-Agent:[KrakenD Version undefined] X-Added:[first second] X-Forwarded-For:[::1] X-Forwarded-Host:[localhost:8080] X-Test:[A CHANGED]]
```
