### PR TITLE
Register http_response decorator to lua-endpoint

### DIFF
--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/url"
 	"strings"
@@ -793,8 +792,6 @@ func Test_Issue7(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
-	fmt.Println(buff.String())
 }
 
 func Test_jsonNumber(t *testing.T) {
@@ -827,7 +824,6 @@ func Test_jsonNumber(t *testing.T) {
 				"post": `
 local resp = response.load()
 local responseData = resp:data()
-print(responseData:get("id"))
 responseData:set("id", responseData:get("id")+1)
 `,
 			},

--- a/router/gin/lua.go
+++ b/router/gin/lua.go
@@ -97,6 +97,7 @@ func process(c *gin.Context, cfg *lua.Config) error {
 	decorator.RegisterNil(b.GetBinder())
 	decorator.RegisterLuaTable(b.GetBinder())
 	decorator.RegisterLuaList(b.GetBinder())
+	decorator.RegisterHTTPRequest(c.Request.Context(), b.GetBinder())
 	registerCtxTable(c, b.GetBinder())
 
 	if err := b.WithConfig(cfg); err != nil {

--- a/router/mux/lua.go
+++ b/router/mux/lua.go
@@ -2,6 +2,7 @@ package mux
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -70,7 +71,6 @@ func HandlerFactory(l logging.Logger, next mux.HandlerFactory, pe mux.ParamExtra
 			if err := process(r, pe, &cfg); err != nil {
 				if errhttp, ok := err.(errHTTP); ok {
 					if e, ok := err.(errHTTPWithContentType); ok {
-						fmt.Println(e.Encoding())
 						w.Header().Add("content-type", e.Encoding())
 					}
 					w.WriteHeader(errhttp.StatusCode())
@@ -107,6 +107,7 @@ func process(r *http.Request, pe mux.ParamExtractor, cfg *lua.Config) error {
 	decorator.RegisterNil(b.GetBinder())
 	decorator.RegisterLuaTable(b.GetBinder())
 	decorator.RegisterLuaList(b.GetBinder())
+	decorator.RegisterHTTPRequest(context.Background(), b.GetBinder())
 	registerRequestTable(r, pe, b.GetBinder())
 
 	if err := b.WithConfig(cfg); err != nil {


### PR DESCRIPTION
The `http_response` has been registered at endpoint level and now can be used in the `pre` and `post` scripts of `modifier/lua-endpoint`