### PR TITLE
Return all headers and params as luaTable

### DIFF
--- a/proxy/request.go
+++ b/proxy/request.go
@@ -112,7 +112,7 @@ func (*ProxyRequest) params(c *binder.Context) error {
 	}
 	switch c.Top() {
 	case 1:
-		return errNeedsArguments
+		c.Push().Data(lua.NewTableFromStringMap(req.Params), "luaTable")
 	case 2:
 		c.Push().String(req.Params[c.Arg(2).String()])
 	case 3:
@@ -129,7 +129,7 @@ func (*ProxyRequest) headers(c *binder.Context) error {
 	}
 	switch c.Top() {
 	case 1:
-		return errNeedsArguments
+		c.Push().Data(lua.NewTableFromStringSliceMap(req.Headers), "luaTable")
 	case 2:
 		key := textproto.CanonicalMIMEHeaderKey(c.Arg(2).String())
 		headers := req.Headers[key]

--- a/proxy/response.go
+++ b/proxy/response.go
@@ -80,7 +80,7 @@ func (*ProxyResponse) headers(c *binder.Context) error {
 	}
 	switch c.Top() {
 	case 1:
-		return errNeedsArguments
+		c.Push().Data(lua.NewTableFromStringSliceMap(resp.Metadata.Headers), "luaTable")
 	case 2:
 		headers := resp.Metadata.Headers[c.Arg(2).String()]
 		if len(headers) == 0 {

--- a/router/gin/lua.go
+++ b/router/gin/lua.go
@@ -203,7 +203,11 @@ func (*ginContext) params(c *binder.Context) error {
 	}
 	switch c.Top() {
 	case 1:
-		return errNeedsArguments
+		params := make(map[string]string)
+		for _, p := range req.Params {
+			params[p.Key] = p.Value
+		}
+		c.Push().Data(lua.NewTableFromStringMap(params), "luaTable")
 	case 2:
 		c.Push().String(req.Params.ByName(c.Arg(2).String()))
 	case 3:
@@ -227,7 +231,7 @@ func (*ginContext) requestHeaders(c *binder.Context) error {
 	}
 	switch c.Top() {
 	case 1:
-		return errNeedsArguments
+		c.Push().Data(lua.NewTableFromStringSliceMap(req.Request.Header), "luaTable")
 	case 2:
 		c.Push().String(req.Request.Header.Get(c.Arg(2).String()))
 	case 3:

--- a/router/mux/lua.go
+++ b/router/mux/lua.go
@@ -204,7 +204,7 @@ func (*muxContext) headers(c *binder.Context) error {
 	}
 	switch c.Top() {
 	case 1:
-		return errNeedsArguments
+		c.Push().Data(lua.NewTableFromStringSliceMap(req.Request.Header), "luaTable")
 	case 2:
 		c.Push().String(req.Header.Get(c.Arg(2).String()))
 	case 3:

--- a/types.go
+++ b/types.go
@@ -15,6 +15,26 @@ type Table struct {
 	Data map[string]interface{}
 }
 
+func NewTableFromStringMap(input map[string]string) *Table {
+	data := make(map[string]interface{})
+	for k, v := range input {
+		data[k] = v
+	}
+	return &Table{Data: data}
+}
+
+func NewTableFromStringSliceMap(input map[string][]string) *Table {
+	data := make(map[string]interface{})
+	for k, v := range input {
+		var list []interface{}
+		for i := range v {
+			list = append(list, v[i])
+		}
+		data[k] = list
+	}
+	return &Table{Data: data}
+}
+
 type List struct {
 	Data []interface{}
 }


### PR DESCRIPTION
Allow calling `headers()` and `params()` dynamic methods from `ctx`, `request` and  `response` objects (when available). Both of them return a luaTable that can be traversed and serialized into JSON

Example:
```lua
function generate_payload(req)
    local payload = {}

    payload.queryStringParameters = parse_url(req:query())
    payload.body = json.unmarshal(req:body())
    payload.headers = req:headers()
    payload.pathParameters = req:params()
    
    local modifiedBody = json.marshal(payload)

    req:body(modifiedBody)
    req:headers('Content-Length', modifiedBody:len())
end
``` 

```lua
-- accessing a specific param
req:params():get('Resp0_foo')
```

```lua
-- accessing an specific value of a multi header
resp:headers():get('Set-Cookie'):get(1)
```